### PR TITLE
fix: firebase test now uses roles table

### DIFF
--- a/tests/Feature/FirebaseAuthTest.php
+++ b/tests/Feature/FirebaseAuthTest.php
@@ -8,10 +8,11 @@ use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use Tests\Traits\UseFirebaseUser;
+use Tests\Traits\UseRolesTable;
 
 class FirebaseAuthTest extends TestCase
 {
-    use RefreshDatabase, UseFirebaseUser;
+    use RefreshDatabase, UseFirebaseUser, UseRolesTable;
 
     public function test_it_fails_without_token(): void
     {


### PR DESCRIPTION
Fix the error for roles not found on firebase test when running the tests on a fresh database.