### PR TITLE
feat: Add Calendars to the API

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -37,9 +37,9 @@ class CalendarController extends Controller
         return $calendar;
     }
 
-    public function delete(Calendar $calendar)
+    public function destroy(Calendar $calendar)
     {
         $calendar->delete();
-        return response()->json(['message' => 'Calendar deleted']);
+        return response()->json(['message' => 'Calendar deleted'], 204);
     }
 }

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\AddSectionRequest;
 use App\Http\Requests\StoreCalendarRequest;
 use App\Http\Requests\UpdateCalendarRequest;
 use App\Models\Calendar;
+use App\Models\Section;
 use Illuminate\Http\Request;
 
 class CalendarController extends Controller
@@ -41,5 +43,46 @@ class CalendarController extends Controller
     {
         $calendar->delete();
         return response()->json(['message' => 'Calendar deleted'], 204);
+    }
+
+    // Section related functions
+    public function sections(Calendar $calendar)
+    {
+        return $calendar->sections;
+    }
+
+    public function addSection(AddSectionRequest $request, Calendar $calendar)
+    {
+        $validated = $request->validated();
+        // Check if section exists in calendar
+        if ($calendar->sections()->where('id', $validated['section_id'])->exists()) {
+            return response()->json(['message' => 'Section already exists in calendar'], 409);
+        }
+
+        // Check if section is from same academic charge
+        $section = $calendar->academicCharge->sections()->where('id', $validated['section_id'])->first();
+        if (!$section) {
+            return response()->json(['message' => 'Section does not exist in academic charge'], 404);
+        }
+
+        // TODO: Check if calendarable type id is the same as section school or career
+
+
+        // Attach section
+        $calendar->sections()->attach($section);
+        
+        return response()->json([
+            'message' => 'Section added to calendar',
+            'calendar' => $calendar
+        ], 201);
+    }
+
+    public function removeSection(Calendar $calendar, Section $section)
+    {
+        $calendar->sections()->detach($section);
+        return response()->json([
+            'message' => 'Section removed from calendar',
+            'calendar' => $calendar
+        ], 204);
     }
 }

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreCalendarRequest;
+use App\Http\Requests\UpdateCalendarRequest;
+use App\Models\Calendar;
+use Illuminate\Http\Request;
+
+class CalendarController extends Controller
+{
+    public function index(Request $request) {
+        $user = auth()->user();
+
+        return $user->calendars;
+    }
+
+    public function show(Calendar $calendar) {
+        return $calendar;
+    }
+
+    public function store(StoreCalendarRequest $request) 
+    {
+        // Authorization handled inside form request
+        $validated = $request->validated();
+        $calendar = Calendar::create($validated);
+
+        return $calendar;
+    }
+
+    public function update(UpdateCalendarRequest $request, Calendar $calendar)
+    {
+        // Authorization handled inside form request
+        $validated = $request->validated();
+        $calendar->update($validated);
+        return $calendar;
+    }
+
+    public function delete(Calendar $calendar)
+    {
+        $calendar->delete();
+        return response()->json(['message' => 'Calendar deleted']);
+    }
+}

--- a/app/Http/Requests/AddSectionRequest.php
+++ b/app/Http/Requests/AddSectionRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddSectionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'section_id' => ['required', 'integer', 'exists:academic_charge_subject,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreCalendarRequest.php
+++ b/app/Http/Requests/StoreCalendarRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCalendarRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'uuid' => ['sometimes', 'string', 'max:255'],
+            'is_public' => ['sometimes', 'boolean'],
+            'options' => ['sometimes', 'nullable', 'json'],
+            'academic_charge_id' => ['sometimes', 'nullable', 'exists:academic_charges,id'],
+            'calendarable_id' => ['required', 'exists:careers,id'],
+            'calendarable_type' => ['required', 'string', 'in:career,school'],
+        ];
+    }
+
+    // modify after validation passs
+    public function passedValidation()
+    {
+        $this->merge([
+            'user_id' => auth()->user()->id,
+            'calendarable_type' => "App\Models\\" . ucfirst($this->calendarable_type),
+        ]);
+    }
+}

--- a/app/Http/Requests/UpdateCalendarRequest.php
+++ b/app/Http/Requests/UpdateCalendarRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCalendarRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'is_public' => ['sometimes', 'boolean'],
+            'description' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'options' => ['sometimes', 'nullable', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Resources/Identifiers/AcademicChargeIdentifier.php
+++ b/app/Http/Resources/Identifiers/AcademicChargeIdentifier.php
@@ -14,9 +14,10 @@ class AcademicChargeIdentifier extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $full_name = str_replace('-', ' ', $this->name);
         return [
             'id' => $this->id,
-            'full_name' => "{$this->name} {$this->year}-{$this->semester}",
+            'full_name' => "{$full_name} {$this->year}-{$this->semester}",
             'url' => route('academic-charges.show', $this->id),
         ];
     }

--- a/app/Http/Resources/Identifiers/CareerIdentifier.php
+++ b/app/Http/Resources/Identifiers/CareerIdentifier.php
@@ -15,9 +15,9 @@ class CareerIdentifier extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            'id'    => $this->id,
-            'name'  => $this->name,
-            'url'   => 'Not implemented yet'
+            'id' => $this->id,
+            'name' => str_replace('-', ' ', $this->name),
+            'url' => 'Not implemented yet'
         ];
     }
 }

--- a/app/Models/Calendar.php
+++ b/app/Models/Calendar.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Calendar extends Model
+{
+    use HasFactory;
+
+    protected $guard_name = 'web';
+
+    public $fillable = [
+        'uuid',
+        'is_public',
+        'name',
+        'description',
+        'options', // Custom data that user provides
+        'user_id',
+        'academic_charge_id',
+        'calendarable_id',
+        'calendarable_type',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function charge(): BelongsTo
+    {
+        return $this->belongsTo(AcademicCharge::class, 'academic_charge_id');
+    }
+
+    public function sections(): BelongsToMany
+    {
+        return $this->belongsToMany(Section::class, 'calendar_section', 'calendar_id', 'section_id');
+    }
+
+    public function calendarable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function getCalendarableClass()
+    {
+        return $this->calendarable_type;
+    }
+
+    public function scopePublic($query)
+    {
+        return $query->where('is_public', true);
+    }
+}

--- a/app/Models/Calendar.php
+++ b/app/Models/Calendar.php
@@ -26,6 +26,11 @@ class Calendar extends Model
         'calendarable_type',
     ];
 
+    public function academicCharge(): BelongsTo
+    {
+        return $this->belongsTo(AcademicCharge::class, 'academic_charge_id');
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');

--- a/app/Models/Career.php
+++ b/app/Models/Career.php
@@ -18,4 +18,9 @@ class Career extends Model
     {
         return $this->hasMany(Section::class);
     }
+
+    public function calendars(): HasMany
+    {
+        return $this->hasMany(Calendar::class, 'calendarable_id');
+    }
 }

--- a/app/Models/Section.php
+++ b/app/Models/Section.php
@@ -19,6 +19,8 @@ class Section extends Model
     protected $fillable = [
         'academic_charge_id',
         'subject_id',
+        'career_id',
+        'school_id',
         'code',
         'shift',
         'teacher',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
@@ -20,6 +21,11 @@ class User extends Authenticatable
         'name',
         'email',
     ];
+
+    public function calendars(): HasMany
+    {
+        return $this->hasMany(Calendar::class);
+    }
 
     // Tells the database not to auto-increment this field
     public function getIncrementing ()

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -28,6 +28,10 @@ class RouteServiceProvider extends ServiceProvider
             return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
         });
 
+        Route::bind('calendar', function ($value) {
+            return \App\Models\Calendar::where('uuid', $value)->firstOrFail();
+        });
+
         $this->routes(function () {
             Route::middleware('api')
                 ->prefix('api')

--- a/database/factories/CalendarFactory.php
+++ b/database/factories/CalendarFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AcademicCharge;
+use App\Models\Career;
+use App\Models\School;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Calendar>
+ */
+class CalendarFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $career = Career::factory()->create();
+        $school = School::factory()->create();
+        $calendarable = fake()->randomElement([$career, $school]);
+        return [
+            'name' => fake()->name(),
+            'uuid' => fake()->uuid(),
+            'description' => fake()->text(),
+            'is_public' => fake()->boolean(),
+            'options' => null,
+            'academic_charge_id' => AcademicCharge::factory(),
+            'calendarable_id' => $calendarable->id,
+            'calendarable_type' => get_class($calendarable),
+            'user_id' => null
+        ];
+    }
+}

--- a/database/factories/CareerFactory.php
+++ b/database/factories/CareerFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Career>
+ */
+class CareerFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => Str::slug(fake()->unique()->name()),
+        ];
+    }
+}

--- a/database/factories/SchoolFactory.php
+++ b/database/factories/SchoolFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\School>
+ */
+class SchoolFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => Str::slug(fake()->unique()->name()),
+        ];
+    }
+}

--- a/database/factories/SectionFactory.php
+++ b/database/factories/SectionFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AcademicCharge;
+use App\Models\Career;
+use App\Models\School;
+use App\Models\Subject;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Section>
+ */
+class SectionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'code' => fake()->unique()->randomNumber(4),
+            'shift' => fake()->randomElement(['M', 'T', 'N']),
+            'teacher' => fake()->name(),
+            'academic_charge_id' => AcademicCharge::factory(),
+            'subject_id' => Subject::factory(),
+            'career_id' => Career::factory(),
+            'school_id' => School::factory(),
+        ];
+    }
+}

--- a/database/factories/SubjectFactory.php
+++ b/database/factories/SubjectFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Subject>
+ */
+class SubjectFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'code' => (string) fake()->unique()->numberBetween(1000, 9999),
+            'level' => fake()->numberBetween(0, 9)
+        ];
+    }
+}

--- a/database/migrations/2023_10_03_002556_create_calendars_table.php
+++ b/database/migrations/2023_10_03_002556_create_calendars_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('calendars', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique(); // for public purposes
+            $table->boolean('is_public')->default(false); // for public purposes
+            $table->string('name');
+            $table->string('description')->nullable();
+            $table->json('options')->nullable();
+
+            $table->string('user_id')->nullable();
+            $table->foreignId('academic_charge_id')->constrained()->cascade('set null');
+            $table->morphs('calendarable'); // schools or careers
+
+            $table->timestamps();
+
+            // Constraints
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->cascade('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('calendars');
+    }
+};

--- a/database/migrations/2023_10_03_002556_create_calendars_table.php
+++ b/database/migrations/2023_10_03_002556_create_calendars_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 
 return new class extends Migration
 {
@@ -13,7 +14,7 @@ return new class extends Migration
     {
         Schema::create('calendars', function (Blueprint $table) {
             $table->id();
-            $table->string('uuid')->unique(); // for public purposes
+            $table->string('uuid')->unique()->default(Str::uuid()); // for public purposes
             $table->boolean('is_public')->default(false); // for public purposes
             $table->string('name');
             $table->string('description')->nullable();

--- a/database/migrations/2023_10_03_003758_create_calendar_section_table.php
+++ b/database/migrations/2023_10_03_003758_create_calendar_section_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('calendar_section', function (Blueprint $table) {
+            $table->foreignId('calendar_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('section_id');
+
+            $table->foreign('section_id')
+                ->references('id')
+                ->on('academic_charge_subject')
+                ->cascadeOnDelete();
+
+            $table->primary(['calendar_id', 'section_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('calendar_section');
+    }
+};

--- a/database/seeders/CsvDataSeeder.php
+++ b/database/seeders/CsvDataSeeder.php
@@ -46,8 +46,8 @@ class CsvDataSeeder extends Seeder
         }
 
         // Many to many relationships needs to be seeded manually
-        $shceduleSectionPath = base_path('database/csv/schedule_section.csv');
-        $scheduleSectionCsvData = array_map('str_getcsv', file($shceduleSectionPath));
+        $scheduleSectionPath = base_path('database/csv/schedule_section.csv');
+        $scheduleSectionCsvData = array_map('str_getcsv', file($scheduleSectionPath));
         $scheduleSectionHeaders = array_shift($scheduleSectionCsvData);
         $scheduleSectionHeaders[0] = 'schedule_id';
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,4 +64,4 @@ Route::apiResource('calendars', CalendarController::class)
 
 // Show for calendars needs to be outside middleware because there
 // are public calendars that don't need to be authenticated
-Route::get('/calendars/{calendar}', [CalendarController::class])->name('calendars.show');
+Route::get('/calendars/{calendar}', [CalendarController::class, 'show'])->name('calendars.show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,8 @@
 <?php
 
 // Controllers
+
+use App\Http\Controllers\CalendarController;
 use App\Http\Controllers\v1\AcademicChargeController;
 use App\Http\Controllers\v1\FirebaseAuthController;
 use Illuminate\Support\Facades\Route;
@@ -54,3 +56,12 @@ Route::prefix('/academic-charges/{charge}')->group(function () {
     Route::get('/careers', [AcademicChargeController::class, 'careers'])->name('academic-charges.careers');
     Route::get('/schools', [AcademicChargeController::class, 'schools'])->name('academic-charges.schools');
 });
+
+Route::apiResource('calendars', CalendarController::class)
+    ->middleware('auth.firebase')
+    ->except('show')
+    ->parameters(['calendars' => 'calendar']);
+
+// Show for calendars needs to be outside middleware because there
+// are public calendars that don't need to be authenticated
+Route::get('/calendars/{calendar}', [CalendarController::class])->name('calendars.show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,4 +64,9 @@ Route::apiResource('calendars', CalendarController::class)
 
 // Show for calendars needs to be outside middleware because there
 // are public calendars that don't need to be authenticated
-Route::get('/calendars/{calendar}', [CalendarController::class, 'show'])->name('calendars.show');
+Route::prefix('/calendars/{calendar}')->group(function () {
+    Route::get('/', [CalendarController::class, 'show'])->name('calendars.show');
+    Route::get('/sections', [CalendarController::class, 'calendarSections'])->name('calendars.sections');
+    Route::post('/sections', [CalendarController::class, 'addSection'])->name('calendars.sections.store');
+    Route::delete('/sections/{section}', [CalendarController::class, 'removeSection'])->name('calendars.sections.destroy');
+});

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -106,7 +106,7 @@ class CalendarTest extends TestCase
         ];
         $this->actingAsFirebaseUser();
 
-        $response = $this->putJson(route('calendars.update', $calendar->id), $data);
+        $response = $this->putJson(route('calendars.update', $calendar->uuid), $data);
 
         $response->assertStatus(200);
         $this->assertDatabaseHas('calendars', [
@@ -123,7 +123,7 @@ class CalendarTest extends TestCase
         ]);
         $this->actingAsFirebaseUser();
 
-        $response = $this->deleteJson(route('calendars.destroy', $calendar->id));
+        $response = $this->deleteJson(route('calendars.destroy', $calendar->uuid));
 
         $response->assertStatus(204);
         $this->assertDatabaseMissing('calendars', [
@@ -143,7 +143,7 @@ class CalendarTest extends TestCase
         ]);
         $this->actingAsFirebaseUser();
 
-        $response = $this->postJson(route('calendars.sections.store', $calendar->id), [
+        $response = $this->postJson(route('calendars.sections.store', $calendar->uuid), [
             'section_id' => $section->id
         ]);
 
@@ -167,7 +167,7 @@ class CalendarTest extends TestCase
         $calendar->sections()->attach($section);
         $this->actingAsFirebaseUser();
 
-        $response = $this->deleteJson(route('calendars.sections.destroy', [$calendar->id, $section->id]));
+        $response = $this->deleteJson(route('calendars.sections.destroy', [$calendar->uuid, $section->id]));
 
         $response->assertStatus(204);
         $this->assertDatabaseMissing('calendar_section', [

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AcademicCharge;
+use App\Models\Calendar;
+use App\Models\Career;
+use App\Models\School;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\UseFirebaseUser;
+use Tests\Traits\UseRolesTable;
+
+class CalendarTest extends TestCase
+{
+    use RefreshDatabase, UseFirebaseUser, UseRolesTable;
+
+    public function test_model_can_morph_for_careers(): void
+    {
+        $user = $this->createUser();
+        $career = Career::factory()->create();
+        $calendar = Calendar::factory()->create([
+            'calendarable_id' => $career->id,
+            'calendarable_type' => get_class($career),
+            'user_id' => $user->id
+        ]);
+
+        $this->assertDatabaseHas('calendars', [
+            'name' => $calendar->name,
+            'description' => $calendar->description,
+            'is_public' => $calendar->is_public,
+            'options' => $calendar->options,
+            'academic_charge_id' => $calendar->academic_charge_id,
+            'calendarable_id' => $calendar->calendarable_id,
+            'calendarable_type' => $calendar->calendarable_type,
+            'user_id' => $calendar->user_id
+        ]);
+        $this->assertTrue(get_class($calendar->calendarable) === get_class($career));
+    }
+
+    public function test_model_can_morph_to_school(): void
+    {
+        $user = $this->createUser();
+        $school = School::factory()->create();
+        $calendar = Calendar::factory()->create([
+            'calendarable_id' => $school->id,
+            'calendarable_type' => get_class($school),
+            'user_id' => $user->id
+        ]);
+
+        $this->assertDatabaseHas('calendars', [
+            'name' => $calendar->name,
+            'description' => $calendar->description,
+            'is_public' => $calendar->is_public,
+            'options' => $calendar->options,
+            'academic_charge_id' => $calendar->academic_charge_id,
+            'calendarable_id' => $calendar->calendarable_id,
+            'calendarable_type' => $calendar->calendarable_type,
+            'user_id' => $calendar->user_id
+        ]);
+    }
+
+    public function test_it_can_get_user_calendars(): void
+    {
+        $user = $this->createUser();
+        Calendar::factory()->count(4)->create();
+        $this->actingAsFirebaseUser();
+            
+        $response = $this->getJson(route('calendars.index'));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_it_allows_identified_users_to_create_calendars(): void
+    {
+        $user = $this->createUser();
+        $charge = AcademicCharge::factory()->create();
+        $career = Career::factory()->create();
+        $data = [
+            'name' => 'Test calendar',
+            'description' => 'Test description',
+            'uuid' => Str::uuid(),
+            'is_public' => true,
+            'academic_charge_id' => $charge->id,
+            'calendarable_id' => $career->id,
+            'calendarable_type' => 'career' // Front does not have the namespaced class
+        ];
+        $this->actingAsFirebaseUser();
+
+        $response = $this->postJson(route('calendars.store'), $data);
+
+        $response->assertStatus(201);
+    }
+
+    public function test_it_allows_owners_to_update_calendars(): void
+    {
+        $user = $this->createUser();
+        $calendar = Calendar::factory()->create([
+            'user_id' => $user->id
+        ]);
+        $data = [
+            'name' => 'Test calendar',
+        ];
+        $this->actingAsFirebaseUser();
+
+        $response = $this->putJson(route('calendars.update', $calendar->id), $data);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('calendars', [
+            'name' => $data['name'],
+            'id' => $calendar->id
+        ]);
+    }
+
+    public function test_it_allows_owners_to_delete_calendars(): void
+    {
+        $user = $this->createUser();
+        $calendar = Calendar::factory()->create([
+            'user_id' => $user->id
+        ]);
+        $this->actingAsFirebaseUser();
+
+        $response = $this->deleteJson(route('calendars.destroy', $calendar->id));
+
+        $response->assertStatus(204);
+        $this->assertDatabaseMissing('calendars', [
+            'id' => $calendar->id
+        ]);
+    }
+}

--- a/tests/Traits/UseFirebaseUser.php
+++ b/tests/Traits/UseFirebaseUser.php
@@ -22,17 +22,24 @@ trait UseFirebaseUser
      * Creates the default test user from firebase auth, but
      * changes the roles to the ones provided in the array.
      */
-    public function createUserWithRoles(Array $roles): User
+    public function createUserWithRoles(Array $roles = null): User
     {
-        $user = User::factory()->create([
+        $user = $this->createUser();
+
+        if ($roles) {
+            $user->syncRoles($roles);
+        }
+
+        return $user;
+    }
+
+    public function createUser(): User
+    {
+        return User::factory()->create([
             'id' => $this->user_id,
             'name' => $this->user_name,  
             'email' => $this->user_email
         ]);
-
-        $user->syncRoles($roles);
-
-        return $user;
     }
     
     /**


### PR DESCRIPTION
This PR adds different routes to manage user calendars and their atacched sections

The routes are the following
| Route | Method | What it does |
| :---| :--- |  :--- |
| `calendars` | GET | List the user calendars |
| `calendars` | POST | Adds a calendar to the user |
| `calendars/{calendar-uuid}`| GET | Gets a calendar |
| `calendars/{calendar-uuid}`| PATCH / PUT | Updates a calendar |
| `calendars/{calendar-uuid}/sections` | POST | Adds a section to the calendar |
| `calendars/{calendar-uuid}/sections/{section}` | Delete| Deletes a section of a calendar |

> **Note**
> This is feature without rules. Policies for this feature will be added on following pull requests