### PR TITLE
fix: `is_public` attribute not sended in CalendarIdentifier

### DIFF
--- a/app/Http/Resources/Identifiers/CalendarIdentifier.php
+++ b/app/Http/Resources/Identifiers/CalendarIdentifier.php
@@ -20,6 +20,7 @@ class CalendarIdentifier extends JsonResource
             'uuid' => $this->uuid,
             'name' => $this->name,
             'calendarable_type' => end($calendarable_type),
+            'is_public' => $this->is_public,
             'calendarable' => [
                 'id' => $this->calendarable_id,
                 'name' => $this->calendarable->name,

--- a/app/Models/Calendar.php
+++ b/app/Models/Calendar.php
@@ -26,6 +26,8 @@ class Calendar extends Model
         'calendarable_type',
     ];
 
+    public $with = ['academicCharge', 'calendarable'];
+
     public function academicCharge(): BelongsTo
     {
         return $this->belongsTo(AcademicCharge::class, 'academic_charge_id');


### PR DESCRIPTION
## What does this PR do?

Front needs a way to identify which calendar is public or private. The identifier resource did not include this. Now it does.