### PR TITLE
fix: public routes cannot get guests users 

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -34,7 +34,9 @@ class Handler extends ExceptionHandler
          * Firebase error handling
          */
         $this->renderable(function (FailedToVerifyToken $e, Request $request) {
-            return response()->json(['status' => 'error','message' => 'Invalid token'], Response::HTTP_UNAUTHORIZED);
+            return response()->json(
+                ['status' => 'error', 'message' => 'Invalid or malformed token'],
+                Response::HTTP_UNAUTHORIZED);
         });
     }
 }

--- a/app/Http/Middleware/FirebaseAuth.php
+++ b/app/Http/Middleware/FirebaseAuth.php
@@ -21,19 +21,28 @@ class FirebaseAuth
 
     /**
      * Handle an incoming request.
+     * This middleware has
      *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $mode strict|optional If the auth methods is optional, the user is not required to be authenticated
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle(Request $request, Closure $next, ?string $mode = 'strict'): Response
     {
         // Check for the token in the header
         $token = $request->bearerToken();
 
-        if (!$token) {
+        // If the auth is optional, the user is not required to be authenticated
+        $optional = $mode === 'optional';
+
+        if (!$token && !$optional) {
             return response()->json(['status' => 'error','message' => 'Token not provided'], Response::HTTP_UNAUTHORIZED);
+        } elseif (!$token && $optional) {
+            // Token not provided but optional, proceed
+            return $next($request);
         }
 
-        // Verify the token
+        // Verify the token as the route is without optional route
         $verifiedIdToken = $this->auth->verifyIdToken(
             $token,
             $checkIfRevoked = true,

--- a/app/Http/Middleware/FirebaseAuth.php
+++ b/app/Http/Middleware/FirebaseAuth.php
@@ -33,20 +33,20 @@ class FirebaseAuth
         $token = $request->bearerToken();
 
         // If the auth is optional, the user is not required to be authenticated
-        $optional = $mode === 'optional';
+        $is_optional = $mode === 'optional';
 
-        if (!$token && !$optional) {
-            return response()->json(['status' => 'error','message' => 'Token not provided'], Response::HTTP_UNAUTHORIZED);
-        } elseif (!$token && $optional) {
-            // Token not provided but optional, proceed
-            return $next($request);
+        if (!$token) {
+            return $is_optional
+                ? $next($request) 
+                : response()->json(['status' => 'error','message' => 'Token not provided'], Response::HTTP_UNAUTHORIZED);
         }
-
+        
+        // From here, the token is present and we can proceed to verify it
         // Verify the token as the route is without optional route
         $verifiedIdToken = $this->auth->verifyIdToken(
             $token,
-            $checkIfRevoked = true,
-            $leewayInSeconds = 3600 // Handle 1 hour of delay from the client
+            false, // Check if the token is revoked
+            3600 // Handle 1 hour of delay from the client
         );
         
         // Set the user in the request and proceed

--- a/app/Policies/CalendarPolicy.php
+++ b/app/Policies/CalendarPolicy.php
@@ -19,12 +19,19 @@ class CalendarPolicy
         // 
     }
 
-    public function view(User $user, Calendar $calendar)
+    public function view(?User $user, Calendar $calendar)
     {
-        // Check if user owns calendar
-        $is_owner = $user->id === $calendar->user_id;
+        // Early exit to public calendar with or without user
+        if ($calendar->is_public) {
+            return Response::allow();
+        }
+
+        // If user is null, then it is a guest
+        if ($user === null) {
+            return Response::deny('You are not allowed to view this calendar');
+        }
         
-        return $is_owner || $calendar->is_public
+        return $user->id === $calendar->user_id
             ? Response::allow()
             : Response::deny('You are not allowed to view this calendar');
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,7 +65,9 @@ Route::apiResource('calendars', CalendarController::class)
 // Show for calendars needs to be outside middleware because there
 // are public calendars that don't need to be authenticated
 Route::prefix('/calendars/{calendar}')->group(function () {
-    Route::get('/', [CalendarController::class, 'show'])->name('calendars.show');
+    Route::get('/', [CalendarController::class, 'show'])
+        ->middleware('auth.firebase:optional')
+        ->name('calendars.show');
     Route::get('/sections', [CalendarController::class, 'calendarSections'])->name('calendars.sections');
     Route::match(['put', 'patch'], '/sections', [CalendarController::class, 'updateSections'])
         ->middleware('auth.firebase')

--- a/tests/Feature/CalendarPrivacyTest.php
+++ b/tests/Feature/CalendarPrivacyTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Calendar;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use Tests\Traits\UseFirebaseUser;
+
+class CalendarPrivacyTest extends TestCase
+{
+    use RefreshDatabase, UseFirebaseUser;
+
+    public function test_it_allows_guests_to_view_public_calendars(): void
+    {
+        $user = $this->createUser();
+        $calendar = Calendar::factory()->create([
+            'user_id' => $user->id,
+            'is_public' => true
+        ]);
+        // Does not use any user to fetch the calendar
+
+        $response = $this->getJson(route('calendars.show', $calendar->uuid));
+
+        $response->assertOk();
+    }
+
+    public function test_it_allows_other_users_to_view_public_calendars(): void
+    {
+        $user1 = User::create(['id' => 'unused-user']);
+        $calendar = Calendar::factory()->create([
+            'user_id' => $user1->id,
+            'is_public' => true
+        ]);
+        $firebaseUser = $this->createUser();
+        $this->actingAsFirebaseUser($firebaseUser);
+
+        $response = $this->getJson(route('calendars.show', $calendar->uuid));
+
+        $response->assertOk();
+    }
+
+    public function test_it_allows_owners_to_view_own_calendars(): void
+    {
+        $user = $this->createUser();
+        $calendar = Calendar::factory()->create([
+            'user_id' => $user->id,
+            'is_public' => false
+        ]);
+        $this->actingAsFirebaseUser($user);
+
+        $response = $this->getJson(route('calendars.show', $calendar->uuid));
+
+        $response->assertOk();
+    }
+
+    public function test_it_denies_guests_to_see_private_calendars(): void
+    {
+        $user = $this->createUser();
+        $calendar = Calendar::factory()->create([
+            'user_id' => $user->id,
+            'is_public' => false
+        ]);
+        // Does not use any user to fetch the calendar
+
+        $response = $this->getJson(route('calendars.show', $calendar->uuid));
+
+        $response->assertForbidden();
+    }
+
+    public function test_it_denies_other_users_to_see_private_calendars(): void
+    {
+        $user = User::create(['id' => 'owner-user']);
+        $calendar = Calendar::factory()->create([
+            'user_id' => $user->id,
+            'is_public' => false
+        ]);
+        $firebaseUser = $this->createUser();
+        $this->actingAsFirebaseUser($firebaseUser);
+
+        $response = $this->getJson(route('calendars.show', $calendar->uuid));
+
+        $response->assertForbidden();
+    }
+
+}

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -192,7 +192,7 @@ class CalendarTest extends TestCase
         $response = $this->postJson(route('calendars.store'), $calendar->toArray());
 
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
-        $response->assertDataMissing('calendars', ['uuid' => $calendar->uuid]);
+        $this->assertDatabaseMissing('calendars', ['uuid' => $calendar->uuid]);
     }
 
     public function test_it_denies_delete_non_owned_calendars(): void

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -183,16 +183,16 @@ class CalendarTest extends TestCase
         ]);
     }
 
-    public function test_it_denies_access_to_private_calendars(): void
+    public function test_it_denies_when_guests_create_calendars(): void
     {
-        $calendar = Calendar::factory()->create([
-            'user_id' => null,
-            'is_public' => false
+        $calendar = Calendar::factory()->make([
+            'user_id' => null
         ]);
 
-        $response = $this->getJson(route('calendars.show', $calendar->uuid));
+        $response = $this->postJson(route('calendars.store'), $calendar->toArray());
 
-        $response->assertStatus(Response::HTTP_FORBIDDEN);
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+        $response->assertDataMissing('calendars', ['uuid' => $calendar->uuid]);
     }
 
     public function test_it_denies_delete_non_owned_calendars(): void


### PR DESCRIPTION
## What does this PR do?

fix #21 

Modified `FirebaseAuth` middleware. It nows can be optional to handle routes that can need users sometimes. The `calendars.show` route is an example of this as this route can be made public by the calendar owner.

Also, the user inside `CalendarPolicy` to `view` a calendar now is optional
```php
// CalendarPolicy.php
public function view(?User $user, Calendar $calendar): Response
{
  //...
}
``` 

Test for calendar privacy were added.