### PR TITLE
refactor: calendar resources and requests

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -37,12 +37,9 @@ class CalendarController extends Controller
         
         // For some reason, the passedValidated does not overwrite the calendarable_type
         $validated['calendarable_type'] = 'App\Models\\' . ucfirst($validated['calendarable_type']);
-        // Check if validate has uuid or generate one
-        if (!isset($validated['uuid'])) {
-            $validated['uuid'] = Str::uuid();
-        }
 
         $calendar = Calendar::create($validated + [
+            'uuid' => Str::uuid(), // Always generate a new uuid
             'user_id' => auth()->user()->id
         ]);
 
@@ -95,9 +92,6 @@ class CalendarController extends Controller
         // sync sections
         $calendar->sections()->sync($validated['sections']);
         
-        return response()->json([
-            'message' => 'Sections updated',
-            'calendar' => $calendar
-        ], 200);
+        return new CalendarResource($calendar);
     }
 }

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -36,11 +36,14 @@ class CalendarController extends Controller
         $validated = $request->validated();
         
         // For some reason, the passedValidated does not overwrite the calendarable_type
-        $validated['calendarable_type'] = 'App\Models\\' . ucfirst($validated['calendarable_type']);
+        $validated['calendarable']['type'] = 'App\Models\\' . ucfirst($validated['calendarable']['type']);
 
         $calendar = Calendar::create($validated + [
             'uuid' => Str::uuid(), // Always generate a new uuid
-            'user_id' => auth()->user()->id
+            'user_id' => auth()->user()->id,
+            'calendarable_type' => $validated['calendarable']['type'],
+            'calendarable_id' => $validated['calendarable']['id'],
+            'academic_charge_id' => $validated['academic_charge']['id'],
         ]);
 
         return new CalendarResource($calendar);

--- a/app/Http/Middleware/FirebaseAuth.php
+++ b/app/Http/Middleware/FirebaseAuth.php
@@ -45,7 +45,7 @@ class FirebaseAuth
         // Verify the token as the route is without optional route
         $verifiedIdToken = $this->auth->verifyIdToken(
             $token,
-            false, // Check if the token is revoked
+            true, // Check if the token is revoked
             3600 // Handle 1 hour of delay from the client
         );
         

--- a/app/Http/Requests/StoreCalendarRequest.php
+++ b/app/Http/Requests/StoreCalendarRequest.php
@@ -30,9 +30,15 @@ class StoreCalendarRequest extends FormRequest
             'description' => ['sometimes', 'nullable', 'string', 'max:255'],
             'is_public' => ['sometimes', 'boolean'],
             'options' => ['sometimes', 'nullable', 'json'],
-            'academic_charge_id' => ['sometimes', 'nullable', 'exists:academic_charges,id'],
-            'calendarable_type' => ['required', 'string', 'in:career,school'],
-            'calendarable_id' => [
+            
+            // Academic charge object validation
+            'academic_charge' => ['required', 'array'],
+            'academic_charge.id' => ['required', 'integer', 'exists:academic_charges,id'],
+            
+            // Calendarable object validation
+            'calendarable' => ['required', 'array'],
+            'calendarable.type' => ['required', 'string', 'in:career,school'],
+            'calendarable.id' => [
                 'required',
                 'integer',
                 // Check if exists in careers or schools table
@@ -41,7 +47,7 @@ class StoreCalendarRequest extends FormRequest
                         $fail('The selected ' . $attribute . ' is invalid.');
                     }
                 }
-            ],
+            ]
         ];
     }
 

--- a/app/Http/Requests/StoreCalendarRequest.php
+++ b/app/Http/Requests/StoreCalendarRequest.php
@@ -28,7 +28,6 @@ class StoreCalendarRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'description' => ['sometimes', 'nullable', 'string', 'max:255'],
-            'uuid' => ['sometimes', 'string', 'max:255'],
             'is_public' => ['sometimes', 'boolean'],
             'options' => ['sometimes', 'nullable', 'json'],
             'academic_charge_id' => ['sometimes', 'nullable', 'exists:academic_charges,id'],

--- a/app/Http/Resources/CalendarResource.php
+++ b/app/Http/Resources/CalendarResource.php
@@ -22,11 +22,11 @@ class CalendarResource extends JsonResource
             'name' => $this->name,
             'description' => $this->description,
             'is_public' => $this->is_public,
-            'options' => $this->options,
-            'calendarable_type' => end($calendarable),
+            'owner_id' => $this->user_id,
             'calendarable' => [
                 'id' => $this->calendarable_id,
                 'name' => $this->calendarable->name,
+                'type' => strtolower(end($calendarable))
             ],
             'academic_charge' => $this->whenLoaded('academicCharge', function () {
                 return AcademicChargeIdentifier::make($this->academicCharge);

--- a/app/Http/Resources/Identifiers/CalendarIdentifier.php
+++ b/app/Http/Resources/Identifiers/CalendarIdentifier.php
@@ -19,16 +19,15 @@ class CalendarIdentifier extends JsonResource
         return [
             'uuid' => $this->uuid,
             'name' => $this->name,
-            'calendarable_type' => end($calendarable_type),
             'is_public' => $this->is_public,
             'calendarable' => [
                 'id' => $this->calendarable_id,
                 'name' => $this->calendarable->name,
+                'type' => strtolower(end($calendarable_type))
             ],
             'academic_charge' => $this->whenLoaded('academicCharge', function () {
                 return AcademicChargeIdentifier::make($this->academicCharge);
             }),
-            'sections' => []
         ];
     }
 }

--- a/app/Models/Calendar.php
+++ b/app/Models/Calendar.php
@@ -19,7 +19,7 @@ class Calendar extends Model
         'is_public',
         'name',
         'description',
-        'options', // Custom data that user provides
+        // 'options', // Custom data that user provides
         'user_id',
         'academic_charge_id',
         'calendarable_id',


### PR DESCRIPTION
## What does this PR do?

This PR basically mimics the calendars objects inside the Frontend, but in the API. Using the same oject to validate the store requests and sending json resources to the front.

There are a few differences, but theresource sent and the one received to the store requests should look like the example above.

```json
{
  "uuid": "string",
  "name": "string",
  "description": "string",
  "is_public": "Bool",
  "calendarable": {
    "id": "string",
    "type": "string career|school",
    "name": "string",
  },
  "academic_charge": {
    "id": "string",
    "name": "string",
    "season": "string",
  },
  "sections": "Array"
}
```